### PR TITLE
Let's us delete an entire set of things in a doctype

### DIFF
--- a/pyelasticsearch.py
+++ b/pyelasticsearch.py
@@ -287,11 +287,17 @@ class ElasticSearch(object):
         response = self._send_request('POST', path, body, {'op_type':'create'}, prepare_body=False)
         return response
 
-    def delete(self, index, doc_type, id):
+    def delete(self, index, doc_type, id=None):
         """
         Delete a typed JSON document from a specific index based on its id.
+
+        If id is omitted, all documents of a given doctype will be deleted.
         """
-        path = self._make_path([index, doc_type, id])
+        path_parts = [index, doc_type]
+        if id:
+            path_parts.append(id)
+
+        path = self._make_path(path_parts)
         response = self._send_request('DELETE', path)
         return response
 

--- a/tests.py
+++ b/tests.py
@@ -62,6 +62,12 @@ class IndexingTestCase(ElasticSearchTestCase):
         result = self.conn.delete("test-index", "test-type", 1)
         self.assertResultContains(result, {'_type': 'test-type', '_id': '1', 'ok': True, '_index': 'test-index'})
 
+    def testDeleteByDocType(self):
+        self.conn.index({"name":"Joe Tester"}, "test-index", "test-type", 1)
+        self.conn.refresh(["test-index"])
+        result = self.conn.delete("test-index", "test-type")
+        self.assertResultContains(result, {'ok': True})
+
     def testDeleteByQuery(self):
         self.conn.index({"name":"Joe Tester"}, "test-index", "test-type", 1)
         self.conn.index({"name":"Bill Baloney"}, "test-index", "test-type", 2)
@@ -88,7 +94,7 @@ class IndexingTestCase(ElasticSearchTestCase):
         self.conn.create_index("another-index")
         result = self.conn.create_index("another-index")
         self.conn.delete_index("another-index")
-        self.assertEqual(result, {'message': "Create index 'another-index' errored: Non-OK status code returned (400) containing u'IndexAlreadyExistsException[[another-index] Already exists]'."})
+        self.assertEqual(result, {'message': "Create index 'another-index' errored: Non-OK status code returned (400) containing 'IndexAlreadyExistsException[[another-index] Already exists]'."})
         self.assertRaises(ElasticSearchError, self.conn.delete_index, "another-index", quiet=False)
 
     def testPutMapping(self):


### PR DESCRIPTION
I also had to change a test, not sure if it was me using simplejson vs json or what, but it kept failing when there was a u'' in there.  I'm happy to make it smarter and more tolerant, before you merge.
